### PR TITLE
🐛 Fix double decompress

### DIFF
--- a/custom_components/geovelo/__init__.py
+++ b/custom_components/geovelo/__init__.py
@@ -152,6 +152,7 @@ class GeoveloAPICoordinator(DataUpdateCoordinator):
                 "No traces loaded from cache, it should only happen when installing this integration"
             )
             return None
+        traces = copy.deepcopy(traces)
         for i, trace in enumerate(traces):
             for key in self.COMPRESSED_KEYS:
                 self._decompress_key(trace, key, i)


### PR DESCRIPTION
Due to the way DataCoordinator are made, the data is fetched twice at startup. This is a behavior that I don't know yet how to fix (probably with a debouncer).
This, in combination with usage of `Store` class, leads to load data from cache **twice**.
`Store` class has some clever mechanism to join two concurrent load tasks in one.
This results in the **same** object being returned by two concurrent loads, which are uncompressed twice.
A deep copy mitigates this (even though we still load twice)

This is probably the same issue than affects my other integrations (see https://github.com/kamaradclimber/rte-ecowatt/issues/79 for instance)

Reference: https://github.com/home-assistant/core/blob/858fb1fa376af47e570b0a9f718502de2b0d2636/homeassistant/helpers/storage.py#L125-L126