### PR TITLE
Fix GeoveloUtilityMeterSensor construction for HA 2026.8 (UtilityMeterSensor dropped `hass` again)

### DIFF
--- a/custom_components/geovelo/__init__.py
+++ b/custom_components/geovelo/__init__.py
@@ -4,6 +4,7 @@ import json
 import gzip
 import copy
 import base64
+import inspect
 import urllib.parse
 import logging
 from functools import partial
@@ -246,10 +247,13 @@ class GeoveloUtilityMeterSensor(UtilityMeterSensor):
         self._attr_icon = args["icon"]
         del args["icon"]
         del args["device_class"]
-        if AwesomeVersion(HA_VERSION) < AwesomeVersion("2025.8"):
-            super().__init__(**args)
-        else:
-            super().__init__(hass, **args)
+        # HA core removed the `hass` constructor argument from UtilityMeterSensor
+        # in 2026.8 (home-assistant/core#177603). Inspect the installed
+        # signature instead of comparing HA_VERSION so this keeps working both
+        # before and after that change, regardless of which side we're on.
+        if "hass" in inspect.signature(UtilityMeterSensor.__init__).parameters:
+            args["hass"] = hass
+        super().__init__(**args)
 
 
     @property


### PR DESCRIPTION
Fixes #32.

## What

`GeoveloUtilityMeterSensor` (`custom_components/geovelo/__init__.py:243-252`) subclasses `homeassistant.components.utility_meter.sensor.UtilityMeterSensor` and picked between `super().__init__(**args)` and `super().__init__(hass, **args)` based on `AwesomeVersion(HA_VERSION) < AwesomeVersion("2025.8")`.

That assumed `hass` would stay a required constructor argument from 2025.8 onward indefinitely. **HA 2026.8.0 (released today, 2026-08-05) reverses it**: `home-assistant/core#177603` (merged 2026-07-30) removed `hass` from `UtilityMeterSensor.__init__` and made every remaining parameter keyword-only:

```python
# HA 2026.7.3
def __init__(self, hass, *, cron_pattern, ..., suggested_entity_id=None): ...

# HA 2026.8.0
def __init__(self, *, cron_pattern, ..., suggested_entity_id=None, device=None): ...
```

So on 2026.8+, `GeoveloUtilityMeterSensor(self.hass, **kwargs)` (called from `async_added_to_hass` for any `monthly_utility` sensor) now raises a `TypeError` from the `super().__init__(hass, **args)` branch, since the base class no longer accepts a positional `hass` at all.

**This is not in HA's official breaking-changes list** — the core team treats these helper-entity constructors as internal API — so it won't appear in any changelog integration authors watch. It'll only surface through user reports once people update.

## Fix

Detect at runtime whether the installed `UtilityMeterSensor.__init__` still accepts `hass` via `inspect.signature`, and pass it only then, instead of a version comparison that has now flipped direction once already:

```python
if "hass" in inspect.signature(UtilityMeterSensor.__init__).parameters:
    args["hass"] = hass
super().__init__(**args)
```

Same pattern already in use elsewhere in the HACS ecosystem for this exact HA-core change (`bramstroker/homeassistant-powercalc`, `nathanmarlor/foxess_modbus` — explicit `inspect.signature(IntegrationSensor.__init__)` — and `Olen/homeassistant-plant#500`, merged 2026-07-30, citing `home-assistant/core#177596/#177597/#177603`).

One trap avoided on purpose: `gbbirkisson/gbb-ha` also calls `inspect.signature`, but only to gate an unrelated kwarg while still passing `hass` positionally unconditionally — so it looks defended but isn't. This fix's check is specifically for `hass`, and passes it as a keyword (not positional), since positional `hass` is exactly what the 2026.8 kw-only signature rejects.

The unrelated `AwesomeVersion(HA_VERSION) < AwesomeVersion("2025.8")` check further down (line ~305, gating whether `device_info` is passed) is untouched — that's a separate, still-valid HA<2025.8 compatibility shim unrelated to this bug, so I left it alone to keep the diff minimal. `AwesomeVersion`/`HA_VERSION` therefore stay imported.

## Same bug, same maintainer

`kamaradclimber/heishamon-homeassistant` has the identical pattern in `EnergyIntegrationEntity`/`IntegrationSensor` (companion PR: https://github.com/kamaradclimber/heishamon-homeassistant/pull/389), flagging it here in case it's useful context for reviewing this one.

## What I validated / didn't

- I don't own a Geovelo account/bike/tracker, so no end-to-end HA runtime test was possible.
- This repo has no test suite (only HACS/hassfest validation workflows), so there's nothing to run and diff via `git stash`.
- What I *did* verify: fetched the real `UtilityMeterSensor.__init__` source from `home-assistant/core` at tag `2026.7.3` (pre-change, `hass` positional) and tag `2026.8.0` (post-change, `hass` removed, kw-only) via the GitHub API, stubbed both signatures locally, and ran the exact fixed `GeoveloUtilityMeterSensor.__init__` logic against both — construction succeeds and `hass` is only forwarded when the base class accepts it, in both cases.

## Diff

Minimal: only the `hass`-forwarding branch in `GeoveloUtilityMeterSensor.__init__`, plus the added `import inspect`.

I know this repo's been quiet since 2025-09 — happy to wait, just wanted the fix + issue on record before 2026.8 adoption picks up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
